### PR TITLE
README.md -  english translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-Roamon-verify is developed and maintained by JPNIC young dev team.
-
 ## Documentation
 
 Roamon-verify is a command line tool to show ROV results from BGP routes.
 This tool uses routeviews archive as BGP routes and VRP (Validated ROA prefixes) from Routinator.
+Roamon-verify is developed and maintained by JPNIC young dev team.
 
 ## Installation
 
@@ -84,7 +83,7 @@ To see results:
 Announced prefixes by all AS in VRPs are 'ROV'ed by default.
 
 ```
-$ python3 roamon_verify_controller.py check
+$ python3 roamon_verify_controller.py show
 
 64511    192.168.1.0/24 VALID
 64511    172.16.0.0/16 VALID
@@ -97,7 +96,7 @@ $ python3 roamon_verify_controller.py check
 Verify all prefixes annouced by specified AS(es).
 64511 and 64510 as examples.
 ```
-$ python3 roamon_verify_controller.py check -asns 64511 64510
+$ python3 roamon_verify_controller.py show -asn 64511 64510
 
 64511    192.168.1.0/24 VALID
 64510    10.0.0.0/8 INVALID
@@ -107,7 +106,7 @@ $ python3 roamon_verify_controller.py check -asns 64511 64510
 
 Verify longest-matched prefix in BGP routes with specified prefix.
 ```
-$ python3 roamon_verify_controller.py check -ips 192.168.1.0/24 10.0.0.0/8
+$ python3 roamon_verify_controller.py show -ip 192.168.1.0/24 10.0.0.0/8
 
 192.168.1.0/24   VALID
 10.0.0.0/8   INVALID
@@ -115,7 +114,7 @@ $ python3 roamon_verify_controller.py check -ips 192.168.1.0/24 10.0.0.0/8
 
 If shorter prefixes found from specified prefix(es) exist, it will be verified.
 ```
-$ python3 roamon_verify_controller.py check -ips 172.16.1.0/20
+$ python3 roamon_verify_controller.py show -ip 172.16.1.0/20
 
 172.16.1.0/15   NOT_ADVERTISED
 ```


### PR DESCRIPTION
This is a partial english translation from Japanese README.md.

Spec related notes: (code related issue)
Usage of showing longer BGP prefix could be also considered. It is when finding BGP routes from allocated prefixes.

Code related notes:
When 'INVALID', showing related ROA should helps investigations.